### PR TITLE
Issue#64  チーム情報の操作に関しての機能を整える

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -35,13 +35,13 @@ class AssignsController < ApplicationController
       'メンバーを削除しました。'
     else
       'なんらかの原因で、削除できませんでした。'
-    end    
-  end  
-  
+    end
+  end
+
   def email_reliable?(address)
     address.match(/\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i)
   end
-  
+
   def set_next_team(assign, assigned_user)
     another_team = Assign.find_by(user_id: assigned_user.id).team
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,14 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+    # if current_user == @team.owner
+    # else
+    #   redirect_to @team, notice: 'チームのオーナーではないので編集出来ません！'
+    # end
+
+    redirect_to @team, notice: 'チームのオーナーではないので編集出来ません！' unless current_user == @team.owner
+  end
 
   def create
     @team = Team.new(team_params)
@@ -30,11 +37,15 @@ class TeamsController < ApplicationController
   end
 
   def update
-    if @team.update(team_params)
-      redirect_to @team, notice: 'チーム更新に成功しました！'
+    if current_user == @team.owner
+      if @team.update(team_params)
+        redirect_to @team, notice: 'チーム更新に成功しました！'
+      else
+        flash.now[:error] = '保存に失敗しました、、'
+        render :edit
+      end
     else
-      flash.now[:error] = '保存に失敗しました、、'
-      render :edit
+      redirect_to @team, notice: 'チームのオーナーではないので編集出来ません！'
     end
   end
 

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -41,7 +41,9 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
+                      <% if current_user == @team.owner || current_user == assign.user %>
                       <td><%= link_to '削除', team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>


### PR DESCRIPTION
・Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
→そのTeamのオーナーか、そのUser自身ではない場合には、削除ボタンを出現させないようにしました。

・TeamのeditはTeamのリーダー（オーナー）のみができるようにすること
→現在ログインしているユーザーを確認し、Teamのオーナーではない場合は編集が出来ないようにしました。